### PR TITLE
feat(preset) dev path to resolve.modules config

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,6 @@ in the first argument :
 - `cssImport` - sets postcss-import
   [path](https://www.npmjs.com/package/postcss-import#path),
   the default is: `path.resolve('impl/browser/config')`
+- `devModulesPath` - sets Neutrino
+  [path](https://neutrinojs.org/webpack-chain/#config-resolve-modules),
+  the default is: `dev`

--- a/preset.js
+++ b/preset.js
@@ -6,6 +6,7 @@ module.exports = ({
     publicPath = '/a/browser/',
     source = 'browser',
     output = path.resolve('dist'),
+    devModulesPath = 'dev',
     proxy = {
         context: ['!/a/browser/**'],
         target: 'http://localhost:8004'
@@ -47,6 +48,11 @@ module.exports = ({
         .set('dtrace-provider', require.resolve('./empty'))
         .set('safe-json-stringify', require.resolve('./empty'))
         .set('source-map-support', require.resolve('./empty'));
+    if (process.env.NODE_ENV === 'development') {
+        neutrino.config.resolve.modules
+            .add('node_modules')
+            .prepend(devModulesPath);
+    }
     if (process.env.NODE_ENV === 'production') {
         neutrino.config.optimization
             .minimizer('terser')


### PR DESCRIPTION
[proposal]
Adds the ability to use locally installed ut-<module>s in customizable folder (preferably 'dev') for local development.

![Screenshot from 2020-08-24 14-56-55](https://user-images.githubusercontent.com/6130116/91042444-6cf8bc00-e61a-11ea-8044-ab09eab790f5.png)


